### PR TITLE
Improve service detail page layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -86,6 +86,38 @@ body {
   opacity: 0.8;
 }
 
+.prose-content h1,
+.prose-content h2,
+.prose-content h3 {
+  color: var(--primary-foreground);
+  font-weight: 600;
+  font-size: 1.25rem;
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+.prose-content p {
+  margin-bottom: 1rem;
+}
+
+.prose-content ul {
+  list-style: disc;
+  padding-left: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.prose-content li {
+  margin-bottom: 0.25rem;
+  break-inside: avoid;
+}
+
+@media (min-width: 768px) {
+  .prose-content ul {
+    columns: 2;
+    column-gap: 2rem;
+  }
+}
+
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-playfair), serif;
   text-transform: uppercase;

--- a/app/services/[slug]/page.tsx
+++ b/app/services/[slug]/page.tsx
@@ -3,6 +3,12 @@ import Image from "next/image";
 import Link from "next/link";
 import { getServices, getServiceBySlug } from "lib/content";
 
+function splitContentSections(html: string): string[] {
+  return html.split(/(?=<h1[^>]*>)/i).filter((s) => s.trim());
+}
+
+const sectionBgs = ["bg-secondary", "bg-deep"];
+
 export function generateStaticParams() {
   const services = getServices();
   return services.map((s) => ({ slug: s.slug }));
@@ -34,6 +40,9 @@ export default async function ServiceDetailPage({
   return (
     <main className="min-h-screen bg-primary">
       <article className="mx-auto max-w-3xl px-6 py-12">
+        <Link href="/services" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-accent transition mb-8">
+          ← Back to Services
+        </Link>
         {service.image && (
           <div className="relative aspect-video rounded-xl overflow-hidden mb-8 ring-2 ring-tertiary" {...(service.imageCredit ? { title: service.imageCredit } : {})}>
             <Image
@@ -55,13 +64,20 @@ export default async function ServiceDetailPage({
           </div>
         )}
         {service.summary && (
-          <p className="mt-4 text-lg text-tertiary">{service.summary}</p>
+          <blockquote className="mt-6 border-l-4 border-accent pl-4 text-lg italic text-tertiary">
+            {service.summary}
+          </blockquote>
         )}
         {service.content && (
-          <div
-            className="prose-content mt-8 text-tertiary [&_h3]:text-primary-foreground [&_h3]:font-semibold [&_h3]:mt-6 [&_h3]:mb-2 [&_p]:mb-4 [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:mb-4 [&_li]:mb-1"
-            dangerouslySetInnerHTML={{ __html: service.content }}
-          />
+          <div className="mt-8 space-y-3">
+            {splitContentSections(service.content).map((section, i) => (
+              <div
+                key={i}
+                className={`prose-content text-tertiary rounded-xl px-6 py-6 ${sectionBgs[i % sectionBgs.length]}`}
+                dangerouslySetInnerHTML={{ __html: section }}
+              />
+            ))}
+          </div>
         )}
         {service.ctaText && (
           <div className="mt-12 text-center">


### PR DESCRIPTION
- Add "Back to Services" breadcrumb link
- Style summary field as an accent-bordered blockquote
- Fix prose-content heading styles (was only targeting h3, now h1-h3)
- Move prose styles to globals.css with responsive 2-column bullet lists
- Split content into per-section cards with alternating background colors