### PR TITLE
Make contact-form SMTP provider configurable via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,15 @@
 # and the JSON-LD business schema. No trailing slash.
 SITE_URL=https://example.com
 
-# --- Contact form (nodemailer -> ProtonMail SMTP by default) ---------------
-# SMTP credentials for the mailbox that SENDS the notification email.
+# --- Contact form (nodemailer) ---------------------------------------------
+# SMTP server for the mailbox that SENDS the notification email. Set these to
+# whatever provider the site's email uses. Port 465 = SSL, 587 = STARTTLS.
+#   ProtonMail        smtp.protonmail.ch   587   (paid plan + SMTP token)
+#   Google Workspace  smtp.gmail.com       587   (App Password, 2FA on)
+#   Fastmail          smtp.fastmail.com    465
+#   Resend            smtp.resend.com      465   (user "resend", pass = API key)
+SMTP_HOST=smtp.protonmail.ch
+SMTP_PORT=587
 SMTP_USER=your-sending-address@example.com
 SMTP_PASS=your-smtp-password
 # Where contact-form submissions are delivered.

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -59,10 +59,14 @@ function checkRateLimit(ip: string): { allowed: boolean; remaining: number } {
   return { allowed: true, remaining: RATE_LIMIT_MAX - record.count };
 }
 
+// SMTP is per-site — set host/port to whatever provider the site's email uses
+// (ProtonMail, Google Workspace, Fastmail, Resend, etc.). Port 465 = SSL,
+// 587 = STARTTLS. Defaults to ProtonMail when unset.
+const smtpPort = Number(process.env.SMTP_PORT) || 587;
 const transporter = nodemailer.createTransport({
-  host: "smtp.protonmail.ch",
-  port: 587,
-  secure: false,
+  host: process.env.SMTP_HOST || "smtp.protonmail.ch",
+  port: smtpPort,
+  secure: smtpPort === 465,
   auth: {
     user: process.env.SMTP_USER,
     pass: process.env.SMTP_PASS,


### PR DESCRIPTION
Host/port now come from SMTP_HOST/SMTP_PORT (secure auto-set from port), so the site isn't hardcoded to ProtonMail. Defaults to ProtonMail when unset, preserving current behavior. Documented in .env.example.